### PR TITLE
feat(client/server): add hash validator

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,35 +1,75 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
+import { Crypto } from "./shared/crypto.ts";
+import { Cache } from "./shared/cache.ts";
 
 const API_URL = "http://localhost:8080";
+const crypto = new Crypto();
+const cache = new Cache(crypto);
 
 function App() {
-  const [data, setData] = useState<string>();
+  const [data, setData] = useState<string>("");
+
+
+  const fetchData = useCallback(async () => {
+    const response = await fetch(API_URL);
+    const { data } = await response.json();
+    return data;
+  }, []);
+
+  const getData = useCallback(async () => {
+    try {
+      const data = await fetchData();
+      const decryptedData = crypto.decrypt(data);
+      setData(decryptedData);
+      cache.set("data", decryptedData);
+    } catch (error) {
+      setData(cache.get("data", ""));
+    }
+  }, [setData, fetchData]);
 
   useEffect(() => {
     getData();
-  }, []);
-
-  const getData = async () => {
-    const response = await fetch(API_URL);
-    const { data } = await response.json();
-    setData(data);
-  };
+  }, [getData]);
 
   const updateData = async () => {
-    await fetch(API_URL, {
+    const response = await fetch(API_URL, {
       method: "POST",
-      body: JSON.stringify({ data }),
+      body: JSON.stringify({ data: crypto.encrypt(data) }),
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
     });
 
+    if (response.status !== 200) {
+      alert("Error updating data");
+      return;
+    }
+
+    if (response.status === 200) {
+      alert("Data updated successfully");
+    }
+
     await getData();
   };
 
   const verifyData = async () => {
-    throw new Error("Not implemented");
+    try {
+      const serverData = await fetchData();
+
+      const decryptedData = crypto.decrypt(serverData);
+
+      if (decryptedData !== data) throw new Error("Data is not verified");
+
+      if (data !== decryptedData) throw new Error("Data is not verified");
+      
+      alert("Data is verified!");
+    } catch (error) {
+      setData(cache.get("data", ""));
+      alert(error); 
+    } finally {
+      document.getElementById("data")?.focus();
+    }
   };
 
   return (
@@ -53,6 +93,7 @@ function App() {
         type="text"
         value={data}
         onChange={(e) => setData(e.target.value)}
+        id="data"
       />
 
       <div style={{ display: "flex", gap: "10px" }}>

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
+import App from "./App.tsx";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/client/src/shared/cache.ts
+++ b/client/src/shared/cache.ts
@@ -1,0 +1,57 @@
+import { Crypto } from "./crypto";
+export class Cache {
+  crypto: Crypto;
+
+  constructor(crypto: Crypto) {
+    this.crypto = crypto;
+  }
+
+
+  /**
+   *  get the value from the cache
+   * @param key string
+   * @param defaultValue any 
+   * @returns 
+   */
+  get(key: string, defaultValue: any = null) {
+    console.info(`Getting value from cache with key: ${key}`);
+    const encrypted = localStorage.getItem(key);
+
+    console.info(`Encrypted value: ${encrypted}`);
+
+    if (!encrypted) {
+      console.info(`No value found for key: ${key}`);
+      return defaultValue;
+    }  
+
+    const decrypted = this.crypto.decrypt(encrypted);
+
+    console.info(`Decrypted value: ${decrypted}`);
+
+    return decrypted;
+  }
+
+  /**
+   * Set the value in the cache
+   * @param key string
+   * @param value 
+   */
+  async set(key: string, value: any) {
+    console.info(`Setting value in cache with key: ${key}`);
+    const encrypted = this.crypto.encrypt(value);
+
+    console.info(`Encrypted value: ${encrypted}`);
+    
+    localStorage.setItem(key, encrypted);
+  }
+
+
+  /**
+   * Delete the value from the cache
+   * @param key string
+   */
+  delete(key: string) {
+    console.info(`Deleting value from cache with key: ${key}`);
+    localStorage.removeItem(key);
+  }
+}

--- a/client/src/shared/crypto.ts
+++ b/client/src/shared/crypto.ts
@@ -1,0 +1,57 @@
+export class Crypto {
+  key: string;
+  
+  constructor(key: string = 'mysecretkey') {
+    this.key = key;
+  }
+
+  
+  generateHash(data: string): string {
+    console.info(`Generating hash for: ${data}`);
+    let hash = 0;
+    const combinedData = btoa(data + this.key);
+
+    for (let i = 0; i < combinedData.length; i++) {
+      const char = combinedData.charCodeAt(i);
+      hash = (hash << 5) - hash + char; 
+      hash = hash & hash; 
+    }
+
+    console.info(`Hash generated: ${hash}`);
+   
+    return hash.toString();
+  }
+
+  isValidHash(data: string, hash: string): boolean {
+    console.info(`Validating hash for: ${data} with hash: ${hash}`);
+    const isValid = this.generateHash(data) === hash;
+    console.info(`Hash is valid: ${isValid}`);
+    return isValid;
+  }
+
+  encrypt(data: string): string {
+    console.info(`Encrypting data: ${data}`);
+    const encodedData = btoa(data);
+    console.info(`Data encoded: ${encodedData}`);
+    const hash = this.generateHash(data);
+    console.info(`Hash generated: ${hash}`);
+    const encryptedData = `${hash}:${encodedData}`;
+    console.info(`Data encrypted: ${encryptedData}`);
+    return encryptedData;
+  }
+
+  decrypt(data: string): string {
+    console.info(`Decrypting data: ${data}`);
+    const [hash, encodedData] = data.split(':');
+    console.info(`Data split: hash: ${hash}, encodedData: ${encodedData}`);
+    const decodedData = atob(encodedData);
+    console.info(`Data decoded: ${decodedData}`);
+
+    if (!this.isValidHash(decodedData, hash)) {
+      console.error("Data has been tampered with");
+      throw new Error("Data has been tampered with");
+    }
+
+    return decodedData;
+  }
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,8 +1,10 @@
 import express from "express";
 import cors from "cors";
+import { Crypto } from "../client/src/shared/crypto";
 
 const PORT = 8080;
 const app = express();
+const crypto = new Crypto();
 const database = { data: "Hello World" };
 
 app.use(cors());
@@ -11,12 +13,27 @@ app.use(express.json());
 // Routes
 
 app.get("/", (req, res) => {
-  res.json(database);
+  const data = crypto.encrypt(database.data);
+  console.info(`Data sent:  $data}`);
+  res.json({ data });
 });
 
 app.post("/", (req, res) => {
-  database.data = req.body.data;
-  res.sendStatus(200);
+  const { data } = req.body;
+
+  console.info(`Data received: ${data}`);
+
+  try {
+    const decrypted = crypto.decrypt(data);
+
+    console.info(`Data decrypted: ${decrypted}`);
+
+    database.data = decrypted;
+    res.sendStatus(200);
+  } catch (error) {
+    console.error("Error: "+ error);
+    res.sendStatus(400);
+  }
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
**1. How does the client ensure that their data has not been tampered with?**

I decided to use a shared encryption mechanism with the same client/server logic, where the sent information is encrypted and hashed, as well as the received information. In the event of a failure on either the client or server side, the information remains unchanged. I believe using this shared concept is interesting to centralize the logic, but I obviously wouldn't leave it so exposed on the client as I did; in something more complex, I would have a better architecture for that.

**2. If the data has been tampered with, how can the client recover the lost data?**

If the data undergoes any suspicious alteration, I have implemented a local cache system that pulls the last stable encrypted version. The server also does not persist data that does not have a valid hash, thus ensuring the integrity of both sides.